### PR TITLE
Disable directory index listing

### DIFF
--- a/2.4/conf/conf-available/dav.conf
+++ b/2.4/conf/conf-available/dav.conf
@@ -3,6 +3,7 @@ Alias / "/var/lib/dav/data/"
 <Directory "/var/lib/dav/data/">
   Dav On
   Options Indexes FollowSymLinks
+  DirectoryIndex disabled
 
   AuthType Basic
   AuthName "WebDAV"


### PR DESCRIPTION
To prevent DoS attack:
Having a file called index.html inside the webdav share will bring sharing to its knees.

To fix this add DirectoryIndex disabled to the config.